### PR TITLE
Update node to 10.28

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -76,7 +76,7 @@ if [ -f "${BUILD_DIR}/nodeversion" ]; then
 fi
 # add a warning if no version of node specified
 if [ "$requested_node_ver" == "" ]; then
-  requested_node_ver="0.10.26"
+  requested_node_ver="0.10.28"
   echo
   echo "No version of Node.js specified in nodeversion, using '${requested_node_ver}'" | indent
   echo


### PR DESCRIPTION
The [latest Meteor](http://docs.meteor.com) requires node 10.28+, so I've updated the dependency for recent metor apps to run.  We could bump it to 10.29 as well, but that does implement an API change in UTF-8 handling that may not be desirable...
